### PR TITLE
Add prefix for security metadata documents

### DIFF
--- a/src/cassim_metadata_cache.erl
+++ b/src/cassim_metadata_cache.erl
@@ -70,7 +70,7 @@ metadata_db_exists() ->
 
 security_meta_id(DbName) ->
     Suffix = list_to_binary(mem3:shard_suffix(DbName)),
-    <<DbName/binary, "/_security", Suffix/binary>>.
+    <<"db/", DbName/binary, "/_security", Suffix/binary>>.
 
 
 start_link() ->

--- a/test/cassim_metadata_cache_test.erl
+++ b/test/cassim_metadata_cache_test.erl
@@ -1,0 +1,24 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(cassim_metadata_cache_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+security_meta_id_test() ->
+    meck:new(mem3),
+    meck:expect(mem3, shard_suffix, fun(_) -> ".shard_suffix" end),
+    ?assertEqual(
+        <<"db/_metadata/_security.shard_suffix">>,
+        cassim_metadata_cache:security_meta_id(<<"_metadata">>)
+    ),
+    meck:unload(mem3).


### PR DESCRIPTION
Because such documents starts with database name, metadata documents
for system databases violates CouchDB restriction for document id which
cannot starts with underscore unless they are not _design/ ones.

COUCHDB-2422
