### PR TITLE
2657 fix cassim fabric calls

### DIFF
--- a/src/cassim_metadata_cache.erl
+++ b/src/cassim_metadata_cache.erl
@@ -198,7 +198,7 @@ load_meta_from_db(DbName, MetaId) ->
         {ok, {ok, #doc{}=Doc}} ->
             couch_doc:to_json_obj(Doc, []);
         {ok, {not_found, deleted}} ->
-            deleted;
+            undefined;
         {ok, {not_found, missing}} ->
             undefined;
         {error, {database_does_not_exist, _}} ->

--- a/src/cassim_security.erl
+++ b/src/cassim_security.erl
@@ -26,6 +26,7 @@
 ]).
 
 -export([
+    migrate_security_props/2,
     validate_security_doc/1
 ]).
 

--- a/src/cassim_security.erl
+++ b/src/cassim_security.erl
@@ -60,6 +60,8 @@ get_security_doc(DbName0) when is_binary(DbName0) ->
             SecProps = fabric:get_security(DbName),
             {ok, SecDoc} = migrate_security_props(DbName, SecProps),
             SecDoc;
+        {error, Error} ->
+            throw(Error);
         SecProps ->
             couch_doc:from_json_obj(SecProps)
     end.


### PR DESCRIPTION
This uses the new `couch_util:with_proc/4` function to prevent calls to `fabric:open_doc/3` from interfering with the the message handling in `cassim_metadata_cache`.

This also adds logic to handle deleted metadata documents, and also conflicts while updating the metadata documents.
