### PR TITLE
Add manual migration logic

### DIFF
--- a/priv/stat_descriptions.cfg
+++ b/priv/stat_descriptions.cfg
@@ -1,0 +1,17 @@
+{[cassim, metadata_cache, hit], [
+    {type, counter},
+    {desc, <<"number of cassim metadata cache lookup hits">>}
+]}.
+{[cassim, metadata_cache, miss], [
+    {type, counter},
+    {desc, <<"number of cassim metadata cache lookup misses">>}
+]}.
+{[cassim, security_migration, success], [
+    {type, counter},
+    {desc, <<"number of successful cassim security doc migrations">>}
+]}.
+{[cassim, security_migration, conflict], [
+    {type, counter},
+    {desc, <<"number of conflicted cassim security doc migrations">>}
+]}.
+

--- a/src/cassim.erl
+++ b/src/cassim.erl
@@ -14,7 +14,9 @@
 
 
 -export([
-    is_enabled/0
+    is_enabled/0,
+    is_active/0,
+    metadata_db_exists/0
 ]).
 
 -export([
@@ -39,7 +41,15 @@
 -include_lib("couch/include/couch_db.hrl").
 
 
+is_active() ->
+    is_enabled() andalso metadata_db_exists().
+
+
 is_enabled() ->
+    config:get_boolean("cassim", "enable", false).
+
+
+metadata_db_exists() ->
     cassim_metadata_cache:metadata_db_exists().
 
 

--- a/src/cassim_metadata_cache.erl
+++ b/src/cassim_metadata_cache.erl
@@ -240,11 +240,14 @@ load_meta(MetaId, _UseCache=false, Db) ->
 fetch_cached_meta(MetaId) ->
     try ets:lookup(?META_TABLE, MetaId) of
         [{MetaId, Props}] ->
+            couch_stats:increment_counter([cassim, metadata_cache, hit]),
             Props;
         [] ->
+            couch_stats:increment_counter([cassim, metadata_cache, miss]),
             couch_log:notice("cache miss on metadata ~s", [MetaId]),
             undefined
         catch error:badarg ->
+            couch_stats:increment_counter([cassim, metadata_cache, miss]),
             couch_log:notice("cache miss on metadata ~s", [MetaId]),
             undefined
     end.

--- a/src/cassim_metadata_cache.erl
+++ b/src/cassim_metadata_cache.erl
@@ -31,6 +31,7 @@
     load_meta/1,
     load_meta/2,
     load_meta/3,
+    fetch_cached_meta/1,
     metadata_db/0,
     metadata_db_exists/0,
     cleanup_old_docs/1
@@ -211,7 +212,7 @@ load_meta_from_db(DbName, MetaId) ->
             {error, timeout};
         Resp ->
             couch_log:notice(
-                "unexpected response retrieving metadata doc [~s/]~s: ~s",
+                "unexpected response retrieving metadata doc [~s/]~s: ~p",
                 [DbName, MetaId, Resp]),
             {error, Resp}
      end.

--- a/src/cassim_security.erl
+++ b/src/cassim_security.erl
@@ -71,8 +71,12 @@ get_security_doc(DbName0, RetryCnt) ->
             SecProps = fabric:get_security(DbName),
             try migrate_security_props(DbName, SecProps) of
                 {ok, SecDoc} ->
+                    couch_stats:increment_counter(
+                        [cassim, security_migration, success]),
                     SecDoc
             catch conflict ->
+                couch_stats:increment_counter(
+                    [cassim, security_migration, conflict]),
                 get_security_doc(DbName0, RetryCnt-1)
             end;
         {error, Error} ->

--- a/src/cassim_security.erl
+++ b/src/cassim_security.erl
@@ -41,7 +41,7 @@ get_security(DbName) ->
 get_security(#db{name=DbName}, Options) ->
     get_security(DbName, Options);
 get_security(DbName, Options) ->
-    case cassim:is_enabled() of
+    case cassim:is_active() of
         true ->
             UserCtx = couch_util:get_value(user_ctx, Options, #user_ctx{}),
             Doc = get_security_doc(DbName),


### PR DESCRIPTION
This adds support for doing manual migration of security documents so that a full migration can be done asynchronously without having to enable `cassim` for all security docs. This is especially useful for high traffic CouchDB instances that don't want to flood `cassim` with migrations.

Companion `chttpd` PR out in https://github.com/apache/couchdb-chttpd/pull/37.
