### PR TITLE
Enable cassim by default

### DIFF
--- a/src/cassim.erl
+++ b/src/cassim.erl
@@ -51,7 +51,7 @@ is_active() ->
 
 
 is_enabled() ->
-    config:get_boolean("cassim", "enable", false).
+    config:get_boolean("cassim", "enable", true).
 
 
 metadata_db_exists() ->


### PR DESCRIPTION
Our current setup is so, that we create _metadata database on cluster setup while cassim is disabled by default. This makes any database security updates [fail](https://github.com/apache/couchdb-chttpd/blob/master/src/chttpd_db.erl#L1525-L1526) with some strange reason about migration that nobody asked to run and that will actually never happens.

Such default behavior is confusing and not what people expected.
