### PR TITLE
Fix changes callback function clause for stop event

### DIFF
--- a/src/cassim_metadata_cache.erl
+++ b/src/cassim_metadata_cache.erl
@@ -166,7 +166,7 @@ changes_callback(waiting_for_updates, Acc) ->
     {ok, Acc};
 changes_callback(start, Since) ->
     {ok, Since};
-changes_callback({stop, EndSeq}, _) ->
+changes_callback({stop, EndSeq, _Pending}, _) ->
     exit({seq, EndSeq});
 changes_callback({change, {Change}}, _) ->
     Id = couch_util:get_value(id, Change),


### PR DESCRIPTION
Because [fabric calls it with 3 element tuple, not two](https://github.com/apache/couchdb-fabric/blob/master/src/fabric_view_changes.erl#L107-L109).
